### PR TITLE
Add argument to formatLabels function

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ new GeoGrid({
     map,
     beforeLayerId: 'labels'
     gridStyle: {
-        color: 'rgba(255, 255, 255, 0.5)'
+        color: 'rgba(255, 255, 255, 0.5)',
         width: 2,
-        dasharray: [5, 10]
+        dasharray: [5, 10],
     },
     labelStyle: {
         color: 'rgba(255, 255, 255, 0.5)',
         fontSize: 18,
-        textShadow: '0 0 10px rgba(0, 0, 0)'
+        textShadow: '0 0 10px rgba(0, 0, 0)',
     },
     zoomLevelRange: [0, 13],
     gridDensity: (zoomLevel) => 10;
-    formatLabels: (degreesFloat) => Math.floor(degreesFloat);
+    formatLabels: (degreesFloat, isLongitude) => Math.floor(degreesFloat);
 });
 ```
 
@@ -106,6 +106,6 @@ To prevent overriding default properties, nest overrides inside `.geogrid-overri
 For example:
 ```css
 .geogrid-overrides .geogrid__label {
-    color: red
+    color: red;
 }
 ```

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -16,7 +16,7 @@ export const createLabelElement = (
     x: number,
     y: number, 
     align: 'left' | 'right' | 'top' | 'bottom',
-    format: (degress: number) => string,
+    format: (degress: number, isLongitude: boolean) => string,
     labelStyle: LabelStyle
 ) => {
     const alignTopOrBottom = align === 'top' || align === 'bottom';
@@ -36,7 +36,7 @@ export const createLabelElement = (
         el.style.textShadow = labelStyle.textShadow;
     }
 
-    el.innerText = format(value);
+    el.innerText = format(value, alignTopOrBottom);
     el.setAttribute(alignTopOrBottom ? 'longitude' : 'latitude', value.toFixed(20));
     el.style.position = 'absolute';
     el.style[alignTopOrBottom ? 'left' : align ] = `${x.toString()}px`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,9 +78,10 @@ export interface GeoGridOptions {
      * A function to format the grid labels.
      * By default, formats the labels as "[degrees]° [minutes]` [seconds]``".
      * @param degreesFloat A floating-point number representing degrees.
+     * @param isLongitude A boolean indicating whether the label is a longitude label.
      * @returns A formatted label string.
      */
-    formatLabels?: (degreesFloat: number) => string
+    formatLabels?: (degreesFloat: number, ) => string
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,7 +81,7 @@ export interface GeoGridOptions {
      * @param isLongitude A boolean indicating whether the label is a longitude label.
      * @returns A formatted label string.
      */
-    formatLabels?: (degreesFloat: number, ) => string
+    formatLabels?: (degreesFloat: number, isLongitude: boolean) => string
 }
 
 /**


### PR DESCRIPTION
I use maplibre to make fictional maps. Some of these use letters in their grid. I want to write my own formatting but it would help first to know if a label coming in is a long or lat. This allows that.